### PR TITLE
Minor corrections for fn:format-integer and fn:format-time

### DIFF
--- a/fn/format-integer.xml
+++ b/fn/format-integer.xml
@@ -260,10 +260,11 @@
         <description>format-integer - picture with different separators, which are irregular</description>
         <created by="O'Neil Delpratt, Saxonica" on="2010-09-28"/>
         <modified by="Michael Kay" on="2016-03-22" change="See bug 29488. Grouping separator must be preceded by digit."/>
+        <modified by="Zachary Dean" on="2019-03-11" change="Result should have leading parenthesis"/>
         <environment ref="empty"/>
         <test>format-integer(602347826, '#(000)000-000')</test>
         <result>
-            <assert-eq>'602)347-826'</assert-eq>
+            <assert-eq>'(602)347-826'</assert-eq>
         </result>    
      </test-case>
      <test-case name="format-integer-031">

--- a/fn/format-integer.xml
+++ b/fn/format-integer.xml
@@ -260,11 +260,10 @@
         <description>format-integer - picture with different separators, which are irregular</description>
         <created by="O'Neil Delpratt, Saxonica" on="2010-09-28"/>
         <modified by="Michael Kay" on="2016-03-22" change="See bug 29488. Grouping separator must be preceded by digit."/>
-        <modified by="Zachary Dean" on="2019-03-11" change="Result should have leading parenthesis"/>
         <environment ref="empty"/>
         <test>format-integer(602347826, '#(000)000-000')</test>
         <result>
-            <assert-eq>'(602)347-826'</assert-eq>
+            <assert-eq>'602)347-826'</assert-eq>
         </result>    
      </test-case>
      <test-case name="format-integer-031">

--- a/fn/format-time.xml
+++ b/fn/format-time.xml
@@ -481,13 +481,17 @@
       <description>test format-time(): effect of width specifiers </description>
       <created by="Debbie Lockett, Saxonica" on="2016-03-24"/>
       <modified by="Michael Kay, Saxonica" on="2016-07-26" change="bug 29749 changes from rounding to truncation"/>
+      <modified by="Zachary Dean" on="2018-12-20" change="result can be '00' as well"/>
       <environment>
          <param name="t" as="xs:time" select="xs:time('09:15:06.006')"/>
       </environment>
       <dependency type="spec" value="XP31+ XQ31+"/>
       <test>format-time($t, '[f,*-2]')</test>
       <result>
-         <assert-string-value>0</assert-string-value>
+        <any-of>
+          <assert-string-value>0</assert-string-value>
+          <assert-string-value>00</assert-string-value>
+        </any-of>
       </result>
    </test-case>
    


### PR DESCRIPTION
- Test 'format-time-023u' can also be "00" as the max width is 2
- Test 'format-integer-030' missing the opening parenthesis in the result