### PR TITLE
fn:serialize() test set

### DIFF
--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -1797,6 +1797,7 @@
     <test-case name="serialize-xml-137b" covers="fn-serialize">
         <description>2nd argument is empty</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-137-src.xml">
                 <description>File to be serialized</description>
@@ -1837,6 +1838,7 @@
     <test-case name="serialize-xml-138b" covers="fn-serialize">
         <description>Options from JSON</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-138-src.xml">
                 <description>File to be serialized</description>
@@ -1867,6 +1869,7 @@
     <test-case name="serialize-xml-139b" covers="fn-serialize">
         <description>Strange key in a character mapping (option parameter conventions apply) </description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-138-src.xml">
                 <description>File to be serialized</description>
@@ -1906,6 +1909,7 @@
         <description>Character mappings and option parameter conventions. Rules are not recursive
             for map value supplied for use-character-maps (required xs:string, element given)</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-138-src.xml">
                 <description>File to be serialized</description>
@@ -1947,6 +1951,7 @@
         <description>Character mappings and option parameter conventions. Rules are not recursive
             for map value supplied for use-character-maps (required xs:string, untypedAtomic and QName given)</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-138-src.xml">
                 <description>File to be serialized</description>
@@ -1982,6 +1987,7 @@
     <test-case name="serialize-xml-142b" covers="fn-serialize">
         <description>Multiple untypedAtomic conversions in one map</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-142-src.xml">
                 <description>File to be serialized</description>

--- a/fn/serialize.xml
+++ b/fn/serialize.xml
@@ -1494,6 +1494,7 @@
             these specifications, or an xs:QName (with non-absent namespace) in the case of 
             implementation-defined serialization parameters. -->
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-xml-120-src.xml">
                 <description>File to be serialized</description>
@@ -2017,6 +2018,7 @@
     <test-case name="serialize-html-001b" covers="fn-serialize">
         <description>serialize test - html method</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-html-001-src.xml">
                 <description>File to be serialized</description>
@@ -2056,6 +2058,7 @@
     <test-case name="serialize-html-002b" covers="fn-serialize">
         <description>serialize test - html method - html-version as xs:integer</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-html-001-src.xml">
                 <description>File to be serialized</description>
@@ -2223,6 +2226,7 @@
     <test-case name="serialize-json-008b" covers="fn-serialize json-output">
         <description>serialize test - params supplied as map, json output method, $arg is a comment node</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-json-008-src.xml">
                 <description>File to be serialized</description>
@@ -2262,6 +2266,7 @@
     <test-case name="serialize-json-009b" covers="fn-serialize json-output">
         <description>serialize test - params supplied as map, json output method, $arg is an array of nodes</description>
         <created by="Debbie Lockett" on="2019-11-19"/>
+        <modified by="Debbie Lockett" on="2020-07-09" change="Source should be XML 1.0"/>
         <environment>        
             <source role="." file="serialize/serialize-json-009-src.xml">
                 <description>File to be serialized</description>

--- a/fn/serialize/serialize-html-001-src.xml
+++ b/fn/serialize/serialize-html-001-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <html><head/><body><p>Hello World!</p></body></html>

--- a/fn/serialize/serialize-json-008-src.xml
+++ b/fn/serialize/serialize-json-008-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <doc><!-- hello world --></doc>

--- a/fn/serialize/serialize-json-009-doc.xml
+++ b/fn/serialize/serialize-json-009-doc.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <a>b</a>

--- a/fn/serialize/serialize-json-009-src.xml
+++ b/fn/serialize/serialize-json-009-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <doc>a<?a b?><!--a--><a>b</a></doc>

--- a/fn/serialize/serialize-xml-120-src.xml
+++ b/fn/serialize/serialize-xml-120-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <e><f/></e>

--- a/fn/serialize/serialize-xml-137-src.xml
+++ b/fn/serialize/serialize-xml-137-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <e/>

--- a/fn/serialize/serialize-xml-138-src.xml
+++ b/fn/serialize/serialize-xml-138-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <e>xml</e>

--- a/fn/serialize/serialize-xml-140-src.xml
+++ b/fn/serialize/serialize-xml-140-src.xml
@@ -1,2 +1,2 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <e>so</e>

--- a/fn/serialize/serialize-xml-142-src.xml
+++ b/fn/serialize/serialize-xml-142-src.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding = "UTF-8"?>
+<?xml version="1.0" encoding = "UTF-8"?>
 <x>
    <e/>
    <f/>


### PR DESCRIPTION
Source files for fn:serialize() tests added 2019-11-19 should be XML 1.0 (not 1.1)