### PR TITLE
Allow both XPTY0019 and XPTY0020

### DIFF
--- a/misc/CombinedErrorCodes.xml
+++ b/misc/CombinedErrorCodes.xml
@@ -1940,12 +1940,14 @@
    </test-case>
 
 
-   <test-case name="XPTY0020">
+   <test-case name="XPTY0019-XPTY0020">
       <description> check that bad context item types are reported correctly </description>
       <created by="Tim Mills" on="2008-05-16"/>
+      <modified by="Christian Gruen" on="2020-08-03" change="Allow both XPTY0019 and XPTY0020"/>
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[<a/>/20[text()]]]></test>
       <result>
+         <error code="XPTY0019"/>
          <error code="XPTY0020"/>
       </result>
    </test-case>

--- a/prod/AxisStep.xml
+++ b/prod/AxisStep.xml
@@ -3935,9 +3935,11 @@ tour:main()
    <test-case name="axis-err-1">
       <description> Evaluation of a step axis, which operates on a non node context item.</description>
       <created by="Carmelo Montanez" on="2005-12-07"/>
+      <modified by="Christian Gruen" on="2020-08-03" change="Allow both XPTY0019 and XPTY0020"/>
       <dependency type="spec" value="XQ10+"/>
       <test><![CDATA[let $var := <anElement>Some content</anElement> return $var/20[child::text()]]]></test>
       <result>
+         <error code="XPTY0019"/>
          <error code="XPTY0020"/>
       </result>
    </test-case>
@@ -4317,8 +4319,10 @@ tour:main()
    <test-case name="K2-Axes-38">
       <description> '..' inside a predicate where the context item is of wrong type.</description>
       <created by="Frans Englich" on="2007-11-26+01:00"/>
+      <modified by="Christian Gruen" on="2020-08-03" change="Allow both XPTY0019 and XPTY0020"/>
       <test>123[..]</test>
       <result>
+         <error code="XPTY0019"/>
          <error code="XPTY0020"/>
       </result>
    </test-case>
@@ -4326,8 +4330,10 @@ tour:main()
    <test-case name="K2-Axes-39">
       <description> 'element()' inside a predicate where the context item is of wrong type.</description>
       <created by="Frans Englich" on="2007-11-26+01:00"/>
+      <modified by="Christian Gruen" on="2020-08-03" change="Allow both XPTY0019 and XPTY0020"/>
       <test>1[element()]</test>
       <result>
+         <error code="XPTY0019"/>
          <error code="XPTY0020"/>
       </result>
    </test-case>


### PR DESCRIPTION
I’ve added both `XPTY0019` and `XPTY0020` to some tests (if an expression is rewritten, it may not be possible anymore to strictly differentiate between these two error states).
