### PR TITLE
Node constructors, EQNames (cont.). w3c/qtspecs#9

### DIFF
--- a/prod/CompAttrConstructor.xml
+++ b/prod/CompAttrConstructor.xml
@@ -1198,4 +1198,154 @@
          <assert-xml>&lt;element attr=""/&gt;</assert-xml>
       </result>
    </test-case>
+
+   <test-case name="Constr-compattr-eqname-1">
+      <description> Constructor with expanded QName, whitespaces</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { " Q{ }x " } {}</test>
+      <result>
+         <assert>$result[local-name() = 'x' and namespace-uri() = '']</assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-2">
+      <description> Constructor with expanded QName, whitespaces</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { " Q{ _   _ }x " } {}</test>
+      <result>
+         <assert>$result[local-name() = 'x' and namespace-uri() = '_ _']</assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-3">
+      <description> Constructor with expanded QName, whitespaces</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { " xml:x " } {}</test>
+      <result>
+         <assert>$result[name() = 'xml:x' and namespace-uri() = 'http://www.w3.org/XML/1998/namespace']</assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-entities-1">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ attribute Q{&#x20;}x {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ' '] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-entities-2">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ attribute { "Q{&#x20;}x" } {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ' '] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-entities-3">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ attribute Q{&#x22;&#x26;}x {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ``["&]``] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-entities-4">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ attribute { "Q{&#x22;&#x26;}x" } {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ``["&]``] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-entities-5">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ attribute Q{&#x7b;&#x7d;}x {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = '{}'] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-1">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { "xml: x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-2">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { "a:x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-3">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute Q{{}x {}</test>
+      <result>
+         <error code="XPST0003"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-4">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute Q{}}x {}</test>
+      <result>
+         <error code="XPST0003"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-5">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { "Q{{}x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-6">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { "Q{&#x7b;}x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compattr-eqname-error-7">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>attribute { "Q{&#x7d;}x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
 </test-set>

--- a/prod/CompElemConstructor.xml
+++ b/prod/CompElemConstructor.xml
@@ -804,4 +804,154 @@
          <error code="XQDY0096"/>
       </result>
    </test-case>
+
+   <test-case name="Constr-compelem-eqname-1">
+      <description> Constructor with expanded QName, whitespaces</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { " Q{ }x " } {}</test>
+      <result>
+         <assert>$result[local-name() = 'x' and namespace-uri() = '']</assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-2">
+      <description> Constructor with expanded QName, whitespaces</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { " Q{ _   _ }x " } {}</test>
+      <result>
+         <assert>$result[local-name() = 'x' and namespace-uri() = '_ _']</assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-3">
+      <description> Constructor with expanded QName, whitespaces</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { " xml:x " } {}</test>
+      <result>
+         <assert>$result[name() = 'xml:x' and namespace-uri() = 'http://www.w3.org/XML/1998/namespace']</assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-entities-1">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ element Q{&#x20;}x {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ' '] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-entities-2">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ element { "Q{&#x20;}x" } {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ' '] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-entities-3">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ element Q{&#x22;&#x26;}x {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ``["&]``] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-entities-4">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ element { "Q{&#x22;&#x26;}x" } {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = ``["&]``] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-entities-5">
+      <description> Constructor with expanded QName, entities</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test><![CDATA[ element Q{&#x7b;&#x7d;}x {} ]]></test>
+      <result>
+         <assert><![CDATA[ $result[local-name() = 'x' and namespace-uri() = '{}'] ]]></assert>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-1">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { "xml: x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-2">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { "a:x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-3">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element Q{{}x {}</test>
+      <result>
+         <error code="XPST0003"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-4">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element Q{}}x {}</test>
+      <result>
+         <error code="XPST0003"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-5">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { "Q{{}x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-6">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { "Q{&#x7b;}x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
+
+   <test-case name="Constr-compelem-eqname-error-7">
+      <description> Constructor with expanded QName, errors</description>
+      <created by="Christian Gruen" on="2020-08-04"/>
+      <dependency type="spec" value="XQ30+" />
+      <test>element { "Q{&#x7d;}x" } {}</test>
+      <result>
+         <error code="XQDY0074"/>
+      </result>
+   </test-case>
 </test-set>


### PR DESCRIPTION
Additional tests, based on the assumption that entities in the URI string are not unescaped dynamically (see https://github.com/w3c/qtspecs/issues/9#issuecomment-667898198).
