### PR TITLE
Add test for outermost where it returns children of siblings

### DIFF
--- a/fn/outermost.xml
+++ b/fn/outermost.xml
@@ -726,4 +726,21 @@
       </result>
    </test-case>
 
+   <test-case name="fn-outermost-059">
+      <description>Check that outermost returns correct descendants that are not siblings</description>
+      <created by="Martin Middel" on="2021-11-29"/>
+      <environment ref="outermost" />
+      <dependency type="spec" value="XQ30+"/>
+      <test>deep-equal(
+            outermost(
+              descendant::comment()
+            ),
+            (
+              descendant::comment()
+            )
+      )</test>
+      <result>
+        <assert-true />
+      </result>
+   </test-case>
 </test-set>


### PR DESCRIPTION
This corresponds to the bug FontoXPath#434 where it attempted to optimize the outermost function by
skipping whole subtrees. However, it skipped all descendants of following elements.