### PR TITLE
Remove XQ31+ dependency for various fn-transform tests

### DIFF
--- a/fn/transform.xml
+++ b/fn/transform.xml
@@ -307,7 +307,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform with minimal options: stylesheet-text, source-node</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -334,7 +334,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform with minimal options: stylesheet-node, source-node</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -360,7 +360,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
     <test-case name="fn-transform-7a">
         <description>Same as -7 but passing the xsl:stylesheet element, not the document node</description>
         <created by="Michael Kay" on="2022-05-17"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -386,7 +386,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
     <test-case name="fn-transform-7b">
         <description>Same as -7 but using a simplified stylesheet</description>
         <created by="Michael Kay" on="2022-05-17"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<out xmlns:xsl='http://www.w3.org/1999/XSL/Transform' xsl:version='2.0'>
@@ -408,7 +408,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
     <test-case name="fn-transform-7c">
         <description>Same as -7 but using a simplified stylesheet passed as an element</description>
         <created by="Michael Kay" on="2022-05-17"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<out xmlns:xsl='http://www.w3.org/1999/XSL/Transform' xsl:version='2.0'>
@@ -430,7 +430,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
     <test-case name="fn-transform-7d">
         <description>Same as -7 but using a simplified stylesheet passed as an element within a document fragment</description>
         <created by="Michael Kay" on="2022-05-17"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<noise/>
@@ -453,7 +453,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
     <test-case name="fn-transform-7e">
         <description>Same as -7 but stylesheet and source are nodes in the same document</description>
         <created by="Michael Kay" on="2022-05-17"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $src  := parse-xml-fragment("<doc>this</doc>
@@ -503,7 +503,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform using option initial-template</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -531,7 +531,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform using option initial-template</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'
@@ -563,7 +563,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform using option initial-template, without source-node</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'
@@ -593,7 +593,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform using option initial-mode</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -626,7 +626,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <modified by="Debbie Lockett" on="2015-04-13" change="Add base-output-uri option"/>
         <modified by="Michael Kay" on="2018-05-21" change="See bug 30209 regarding empty/absent principal result document"/>
         <modified by="Michael Kay" on="2018-06-14" change="Formatted for readability"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
                     let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='3.0'>
@@ -663,7 +663,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <description>Transform producing multiple result documents (with content)</description>
         <created by="Debbie Lockett" on="2015-04-13"/>
         <modified by="Michael Kay" on="2018-05-21" change="See bug 30209 regarding empty/absent principal result document"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
                     let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='3.0'>
@@ -795,7 +795,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
         <created by="Debbie Lockett" on="2015-03-11"/>
         <modified by="Michael Kay" on="2021-05-29" 
             change="allow trailing slash on URI (different string representation of the same URI)"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet version='2.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
@@ -874,7 +874,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style }
     <test-case name="fn-transform-22">
         <description>Transform using xsl:include with relative href, using options stylesheet-text and stylesheet-base-uri</description>
         <created by="Debbie Lockett" on="2015-03-11"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet version='2.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
@@ -1122,7 +1122,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <created by="Debbie Lockett" on="2015-03-25"/>
         <modified by="Debbie Lockett" on="2015-04-13" change="added base-output-uri option"/>
         <modified by="Michael Kay" on="2018-05-21" change="See bug 30209 regarding empty/absent principal result document"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
                     let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='3.0'>
@@ -1266,7 +1266,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <modified by="Michael Kay" on="2016-11-30" change="Bug 29951 - delivery=saved has been dropped"/>
         <modified by="O'Neil Delpratt" on="2017-07-04" change="Bug 30134 - Changed affected assert elements using doc function"/>
         <modified by="Michael Kay" on="2018-05-21" change="See bug 30209 regarding empty/absent principal result document"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
                     let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='3.0'>
@@ -1438,7 +1438,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
             base-output-uri options</description>
         <created by="Debbie Lockett" on="2015-04-13"/>
         <modified by="Michael Kay" on="2018-05-21" change="See bug 30209 regarding empty/absent principal result document"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
                     let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='3.0'>
@@ -1545,7 +1545,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <description>Transform with additional unrecognised option which is ignored</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
         <modified by="Michael Kay" on="2015-11-26" change="avoid HOF dependency in assertions"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -1575,7 +1575,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-50">
         <description>Transform using XSLT 3.0 option static-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1603,7 +1603,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-51">
         <description>Transform using XSLT 3.0 option static-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1632,7 +1632,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-52">
         <description>Transform using XSLT 3.0 option static-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1661,7 +1661,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-53">
         <description>Transform using XSLT 3.0 option template-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1693,7 +1693,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-54">
         <description>Transform using XSLT 3.0 option template-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1729,7 +1729,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-55">
         <description>Transform using XSLT 3.0 option template-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1765,7 +1765,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-56">
         <description>Transform using XSLT 3.0 option template-params (note $param1 is tunnel param so not set)</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1801,7 +1801,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-57">
         <description>Transform using XSLT 3.0 option tunnel-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1837,7 +1837,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-58">
         <description>Transform using XSLT 3.0 options template-params and tunnel-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1878,7 +1878,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <created by="Debbie Lockett" on="2015-04-15"/>
         <modified by="Michael Kay" on="2017-04-05" change="externally-invoked function must be public"/>
         <modified by="Michael Kay" on="2018-06-14" change="default delivery format is 'document', so the result should have a document node"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1921,7 +1921,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <created by="Debbie Lockett" on="2015-04-15"/>
         <modified by="Michael Kay" on="2017-04-05" change="externally-invoked function must be public"/>
         <modified by="Michael Kay" on="2018-06-14" change="default delivery format is 'document', so the result should have a document node"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1964,7 +1964,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-62">
         <description>Transform with XSLT 3.0 delivery-format raw</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -1992,7 +1992,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-63">
         <description>Transform using option initial-template with XSLT 3.0 delivery-format raw</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -2812,7 +2812,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
      <test-case name="fn-transform-err-2">
          <description>Error test case to detect supplied parameters that are mutually exclusive (stylesheet-text and stylesheet-location)</description>
          <created by="O'Neil Delpratt" on="2014-12-09"/>
-         <dependency type="spec" value="XQ31+"/>
+         <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
          <environment ref="works-mod-uri2"/>
       <test><![CDATA[
@@ -2837,8 +2837,8 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
 
      <test-case name="fn-transform-err-3">
       <description>Error test case to detect supplied parameters that are mutually exclusive (stylesheet-text and stylesheet-node)</description>
-      <created by="O'Neil Delpratt" on="2014-12-09"/>
-         <dependency type="spec" value="XQ31+"/>
+         <created by="O'Neil Delpratt" on="2014-12-09"/>
+         <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
          <environment ref="works-mod-uri2"/>
       <test><![CDATA[
@@ -2861,7 +2861,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <description>Error - the type of the value supplied for the option 'xslt-version' is incorrect</description>
         <created by="Debbie Lockett" on="2015-03-05"/>
         <modified by="Tim Mills" on="2016-10-20" change="See Bug 29944" />
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -2883,7 +2883,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <description>Error - the type of the value supplied for the option 'stylesheet-params' is incorrect</description>
         <created by="Debbie Lockett" on="2015-03-05"/>
         <modified by="Tim Mills" on="2016-10-20" change="See Bug 29944" />
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -2904,7 +2904,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-err-6">
         <description>Error test case to detect supplied parameters that are mutually exclusive (initial-mode and initial-template)</description>
         <created by="Debbie Lockett" on="2015-03-03"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'>
@@ -2965,7 +2965,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
             using option stylesheet-text, but without stylesheet-base-uri
         </description>
         <created by="Debbie Lockett" on="2015-03-11"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet version='2.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
@@ -2984,7 +2984,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <created by="Debbie Lockett" on="2015-03-11"/>
         <modified by="Michael Kay" on="2016-11-30" change="No longer an error : bug 30023"/>
         <modified by="Michael Kay" on="2018-09-23" change="As we were saying, this is no longer an error..."/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <test><![CDATA[
             let $xsl  :="<xsl:stylesheet version='2.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
@@ -3095,7 +3095,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
         <description>Error - the initial template defines a required parameter which is not included in
             the map supplied in the XSLT 3.0 transform option template-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -3126,7 +3126,7 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
     <test-case name="fn-transform-err-16">
         <description>Error - transform using XSLT 3.0 option initial-function, but without option function-params</description>
         <created by="Debbie Lockett" on="2015-04-15"/>
-        <dependency type="spec" value="XQ31+"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
         <dependency type="feature" value="fn-transform-XSLT" satisfied="true" />
         <dependency type="feature" value="fn-transform-XSLT30" satisfied="true"/>
         <test><![CDATA[
@@ -3195,8 +3195,8 @@ return transform(map{"source-node":fn:parse-xml($in), "stylesheet-text":$style, 
 
     <test-case name="fn-transform-902">
       <description>Transform using XSLT 3.0 option static-params</description>
-      <created by="Tim Mills" on="2016-09-07"/>
-      <dependency type="spec" value="XQ31+"/>
+        <created by="Tim Mills" on="2016-09-07"/>
+        <modified by="Debbie Lockett" on="2022-08-26" change="Remove XQ31+ dependency; use default XQ31+ XP31+"/>
       <dependency type="feature" value="fn-transform-XSLT" satisfied="false"/>
       <dependency type="feature" value="fn-transform-XSLT30" satisfied="false"/>
       <test><![CDATA[


### PR DESCRIPTION
Update spec dependencies for numerous fn-transform tests: remove XQ31+ dependency to use default XQ31+ XP31+, where no specific XQ31 syntax is used