### PR TITLE
Additional tests with last()

### DIFF
--- a/fn/last.xml
+++ b/fn/last.xml
@@ -261,6 +261,24 @@
       </result>
    </test-case>
 
+   <test-case name="last-26">
+      <description> selection with last() in predicate which contains path expressions </description>
+      <created by="Shuxin Li" on="2023-06-21"/>
+      <test>document{<A><B/><C/></A>}//*[head(./*/last()) <= 1]</test>
+      <result>
+         <assert-empty/>
+      </result>
+   </test-case>
+
+   <test-case name = "last-27">
+      <description> simple node selection with last() </description>
+      <created by="Shuxin Li" on="2023-06-21"/>
+      <test>count(document{<A><B/></A>}//*[last() <= 1])</test>
+      <result>
+         <assert-eq>2</assert-eq>
+      </result>
+   </test-case>
+
    <test-case name="K-ContextLastFunc-1">
       <description> A test whose essence is: `last(1)`. </description>
       <created by="Frans Englich" on="2007-11-26"/>

--- a/fn/last.xml
+++ b/fn/last.xml
@@ -264,7 +264,10 @@
    <test-case name="last-26">
       <description> selection with last() in predicate which contains path expressions </description>
       <created by="Shuxin Li" on="2023-06-21"/>
-      <test>document{<A><B/><C/></A>}//*[head(./*/last()) <= 1]</test>
+      <dependency type="spec" value="XQ30+"/>
+      <test><![CDATA[
+         document{<A><B/><C/></A>}//*[head(./*/last()) <= 1]
+      ]]></test>
       <result>
          <assert-empty/>
       </result>
@@ -273,7 +276,10 @@
    <test-case name = "last-27">
       <description> simple node selection with last() </description>
       <created by="Shuxin Li" on="2023-06-21"/>
-      <test>count(document{<A><B/></A>}//*[last() <= 1])</test>
+      <dependency type="spec" value="XQ30+"/>
+      <test><![CDATA[
+         count(document{<A><B/></A>}//*[last() <= 1])
+      ]]></test>
       <result>
          <assert-eq>2</assert-eq>
       </result>


### PR DESCRIPTION
Additional XPath test cases of node selection related to last(), originated from bug reports