### PR TITLE
Fix #55: avoid implementation-dependent order for map keys

### DIFF
--- a/fn/replace.xml
+++ b/fn/replace.xml
@@ -633,6 +633,15 @@ abracadabra", "\n","with")</test>
             128156, 129446, 32, 252, 228, 246, 36</assert-deep-eq>
       </result>
    </test-case>
+   
+   <test-case name="fn-replace-59">
+      <description>Evaluation of replace with curly braces. SaxonJS bug 6318.</description>
+      <created by="Debbie Lockett after Martin Honnen" on="2024-02-06"/>
+      <test>replace('15/01/24', '(.{2})/(.{2})/(.{2})', '$3$2$1')</test>
+      <result>
+         <assert-string-value>240115</assert-string-value>
+      </result>
+   </test-case>
 
    <test-case name="K-ReplaceFunc-1">
       <description> The flags argument cannot contain whitespace. </description>

--- a/map/merge.xml
+++ b/map/merge.xml
@@ -438,17 +438,18 @@
     <test-case name="map-merge-027">
         <description>Use map:merge() to invert a map, combining duplicates (SaxonJS bug 5855)</description>
         <created by="Debbie Lockett, Saxonica" on="2023-02-22"/>
+        <modified by="Debbie Lockett, Saxonica" on="2023-10-04" change="issue #55: avoid implementation-dependent order for keys"/>
         <environment ref="map"/>
         <test>let $m := map{'a': (1, 2), 'b': 2, 'c': 1, 'd': 3} 
             return map:merge( 
-                for $key in map:keys($m) return for $val in map:get($m, $key) return map{$val : $key}, 
+                for $key in sort(map:keys($m), (), fn:data#1) return for $val in map:get($m, $key) return map{$val : $key}, 
                 map{'duplicates': 'combine'})</test>
         <result>
             <all-of>
                 <assert-count>1</assert-count>
                 <assert-type>map(*)</assert-type>
                 <assert-type>map(xs:integer, xs:string*)</assert-type>
-                <assert>deep-equal(map:keys($result), (1, 2, 3))</assert>
+                <assert>map:size($result) eq 3</assert>
                 <assert>deep-equal($result(1), ("a", "c"))</assert>
                 <assert>deep-equal($result(2), ("a", "b"))</assert>
                 <assert>deep-equal($result(3), ("d"))</assert>


### PR DESCRIPTION
Fix #55: modify test map-merge-027 to avoid implementation-dependent order for map keys